### PR TITLE
[FIX] Fix docs generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,24 @@ python:
   - "3.5"
   - "3.6"
 
+env:
+  global:
+  - PROJECT="OCA Decorators"
+  - GH_NAME="OCA Git Bot"
+  - GH_EMAIL="oca-git-bot@odoo-community.org"
+  matrix:
+  - TESTS="1"
+  - LINT="1"
+  - DOCS="1"
+
 install:
-  - pip install tox-travis
-  - pip install codecov
-  - pip install codeclimate-test-reporter
-
+  - git clone --depth=1 https://github.com/LasLabs/python-quality-tools.git ${HOME}/python-quality-tools
+  - export PATH=${HOME}/python-quality-tools/travis:${PATH}
+  - travis_install
 script:
-  - tox
-
+  - travis_run
 after_success:
-  - codecov
-  - codeclimate-test-reporter
+  - travis_after_success
 
 deploy:
   provider: pypi
@@ -30,4 +37,3 @@ deploy:
     repo: OCA/oca-decorators
     branch: master
     tags: true
-

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@
 # Copyright 2016-2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from setuptools import setup
+from setuptools import Command, setup
 from setuptools import find_packages
+from unittest import TestLoader, TextTestRunner
 
 from os import path
 
@@ -47,10 +48,36 @@ if path.exists(README_FILE):
         setup_vals['long_description'] = fh.read()
 
 
+class FailTestException(Exception):
+    """ It provides a failing build """
+    pass
+
+
+class Tests(Command):
+    """ Run test & coverage, save reports as XML """
+
+    user_options = []  # < For Command API compatibility
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        loader = TestLoader()
+        tests = loader.discover('.', 'test_*.py')
+        t = TextTestRunner(verbosity=1)
+        res = t.run(tests)
+        if not res.wasSuccessful():
+            raise FailTestException()
+
+
 if __name__ == "__main__":
     setup(
         packages=find_packages(exclude=('tests')),
         use_scm_version=True,
+        cmdclass={'test': Tests},
         setup_requires=[
             'setuptools_scm',
         ],


### PR DESCRIPTION
* Move away from Tox in the Travis file, to a known good solution. Fixes OCA#5

[Proof that this works.](https://github.com/LasLabs/oca-decorators/tree/gh-pages)

At the moment, the GitHub account for the OCA bot's password is unknown. Interestingly enough though, Git trickery still allows my account to be used and the Gitbot to be attributed - so this can be merged & I can just make the necessary changes in Travis when I can get in the other account.

We've been quite some time here without documentation, and the only argument against my solution is that it's not standardized. I believe at this point, if the standardized solution did everything we need, a PR would have been submitted. This is my offer for a solution that works right now, and I believe it should be accepted barring a PR within the next few days offering the same featureset:
* Testing including lint, codeclimate, codecov
* Documentation build and push

_Edit: words & features_